### PR TITLE
fix invalid line width

### DIFF
--- a/ical-form.el
+++ b/ical-form.el
@@ -48,7 +48,7 @@ were modified, relative to the old values.")
 (defface ical-form-notes-field
   '((t
      :inherit widget-field
-     :box (:line-width (0 . 0))))
+     :box nil))
   "Face used for editable fields."
   :group 'ical-form)
 


### PR DESCRIPTION
`(0 . 0)` is not a valid line width and gives the following error:
```
(error Invalid face box :line-width (0 . 0))
```

Use `nil` instead: https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html